### PR TITLE
Update /get_statistics message format

### DIFF
--- a/main.py
+++ b/main.py
@@ -360,7 +360,7 @@ def get_statistics(message: Message):
         buf = ''
 
         for item in row:
-            buf += str(item) + '|'
+            buf += str(item) + ' | '
 
         buf += '\n'
         statistics += buf


### PR DESCRIPTION
Right now /get_statistics message looks like this:  
```
valvalx|rating 12.25|toxic 30|positive 79
stxpan|rating 5.75|toxic 23|positive 46
chervyakovru|rating 5.5|toxic 8|positive 30
timbitmashin|rating 4.75|toxic 17|positive 36
hramtsov13|rating 3.0|toxic 6|positive 18
Попов Даниил|rating 1.25|toxic 1|positive 6
MaksimSpirin|rating 0.75|toxic 2|positive 5
kvlad94|rating 0.75|toxic 3|positive 6
Куприков Ил|rating 0.5|toxic 3|positive 5 
```

With this change /get_statistics message will look like this:  
```
valvalx | rating 12.25 | toxic 30 | positive 79
stxpan | rating 5.75 | toxic 23 | positive 46
chervyakovru | rating 5.5 | toxic 8 | positive 30
timbitmashin | rating 4.75 | toxic 17 | positive 36
hramtsov13 | rating 3.0 | toxic 6 | positive 18
Попов Даниил | rating 1.25 | toxic 1 | positive 6
MaksimSpirin | rating 0.75 | toxic 2 | positive 5
kvlad94 | rating 0.75 | toxic 3 | positive 6
Куприков Ил | rating 0.5 | toxic 3 | positive 5 
```

IMHO looks much more readable this way